### PR TITLE
fix: update frontend script paths in package.json and verify lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "app": "node start-app.js",
     "app:start": "node start-app.js",
     "api": "python run_api.py",
-    "frontend": "cd frontend/as_lp && npm run dev",
-    "frontend:build": "cd frontend/as_lp && npm run build",
-    "frontend:install": "cd frontend/as_lp && npm install"
+    "frontend": "cd ui/frontend/as_lp && npm run dev",
+    "frontend:build": "cd ui/frontend/as_lp && npm run build",
+    "frontend:install": "cd ui/frontend/as_lp && npm install"
   },
   "keywords": [
     "satellite",


### PR DESCRIPTION
Regenerated Lockfile: I deleted and re-generated package-lock.json in ui/frontend/as_lp to ensure it is 100% compliant with package.json. The resulting file was identical to the previous one, confirming the local state was valid.
Fixed Scripts: I corrected the root package.json scripts which were pointing to a non-existent frontend/as_lp directory. They now correctly point to ui/frontend/as_lp. This might have been causing the CI to run in the wrong context or fail to find the lockfile.
feat issue #215 