### PR TITLE
fix(metrics): resolve SyntaxError in storage.py

### DIFF
--- a/src/astraguard/hil/metrics/storage.py
+++ b/src/astraguard/hil/metrics/storage.py
@@ -70,12 +70,12 @@ class MetricsStorage:
                 "stats_by_satellite": summary.get("stats_by_satellite", {}),
             }
 
-        summary_path = self.metrics_dir / "latency_summary.json"
-        summary_path.write_text(json.dumps(summary_dict, indent=2, default=str))
+            summary_path = self.metrics_dir / "latency_summary.json"
+            summary_path.write_text(json.dumps(summary_dict, indent=2, default=str))
 
-        # Raw CSV for external analysis
-        csv_path = self.metrics_dir / "latency_raw.csv"
-        collector.export_csv(str(csv_path))
+            # Raw CSV for external analysis
+            csv_path = self.metrics_dir / "latency_raw.csv"
+            collector.export_csv(str(csv_path))
 
             return {"summary": str(summary_path), "raw": str(csv_path)}
         except (OSError, PermissionError) as e:


### PR DESCRIPTION
# 🔧 Fix: Resolve SyntaxError in Metrics Storage & Sync Upstream

## 📝 Description
This Pull Request addresses a critical `SyntaxError` identified in the `MetricsStorage` class (`src/astraguard/hil/metrics/storage.py`) that was preventing the successful execution of HIL latency tests. The issue was traced to an indentation error in the `save_latency_stats` method where the file execution logic was incorrectly dedented outside the `try` block.

Additionally, this PR synchronizes the feature branch with `upstream/main` to ensure the codebase includes the latest updates and is conflict-free.

## 🐛 Issues Fixed
- Fixes `SyntaxError: expected 'except' or 'finally' block` in `src/astraguard/hil/metrics/storage.py`.
- Resolves CI test collection failures for `tests/hil/test_latency_metrics.py`.

## 🛠️ Technical Details
### `src/astraguard/hil/metrics/storage.py`
- **Indentation Fix**: Re-indented lines 73-78 to reside correctly inside the `try` block of the `save_latency_stats` method.
    - Previously, the `summary_path` assignment and write operations were isolated between the `try` block and its corresponding `except` clauses, violating Python syntax rules.

### Metadata
- **Branch**: `fix/docker-env-config` (Synced with `upstream/main`)
- **Tests**: Validated via `pytest`.

## 🧪 Testing Results
- **Command**: `python -m pytest tests/hil/test_latency_metrics.py`
- **Outcome**:
    - ✅ **Passed**: 18 tests
    - ⚠️ **Warnings**: 1 (unrelated DeprecationWarning)
    - ⏱️ **Time**: ~10.81s

## 📋 Checklist
- [x] Code compiles/runs without syntax errors.
- [x] Unit tests passed locally.
- [x] Synced with upstream.
-feat issue #245 