### PR TITLE
Add complete type hints to latency.py

### DIFF
--- a/src/astraguard/hil/metrics/latency.py
+++ b/src/astraguard/hil/metrics/latency.py
@@ -3,6 +3,7 @@
 import time
 import csv
 import logging
+import heapq
 from typing import Dict, List, Any, Optional
 from dataclasses import dataclass, asdict
 from datetime import datetime
@@ -26,10 +27,10 @@ class LatencyMeasurement:
 class LatencyCollector:
     """Captures high-resolution timing data across swarm (10Hz cadence)."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize collector with empty measurements."""
         self.measurements: List[LatencyMeasurement] = []
-        self._start_time = time.time()
+        self._start_time: float = time.time()
         self._measurement_log: Dict[str, int] = defaultdict(int)
 
     def record_fault_detection(
@@ -170,12 +171,12 @@ class LatencyCollector:
         if not self.measurements:
             return {}
 
-        by_satellite = defaultdict(lambda: defaultdict(list))
+        by_satellite: Dict[str, Dict[str, List[float]]] = defaultdict(lambda: defaultdict(list))
 
         for m in self.measurements:
             by_satellite[m.satellite_id][m.metric_type].append(m.duration_ms)
 
-        stats = {}
+        stats: Dict[str, Dict[str, Any]] = {}
         for sat_id, metrics in by_satellite.items():
             stats[sat_id] = {}
             for metric_type, latencies in metrics.items():
@@ -270,7 +271,7 @@ class LatencyCollector:
         count = len(latencies)
 
         # Use heapq to find percentiles without full sort
-        def nth_smallest(n):
+        def nth_smallest(n: int) -> float:
             return heapq.nsmallest(n, latencies)[-1] if n <= count else latencies[-1]
 
         p50_index = count // 2 + 1


### PR DESCRIPTION
## Summary
Added complete Python type annotations to [src/astraguard/hil/metrics/latency.py](cci:7://file:///d:/Contribution/AstraGuard-AI/src/astraguard/hil/metrics/latency.py:0:0-0:0) to improve code reliability and enable strict static type checking for HIL metrics.

Fixes #135 

## Changes
- Added missing `import heapq`
- Added `float` type hint to `_start_time` instance variable
- Added `-> None` return type to [__init__](cci:1://file:///d:/Contribution/AstraGuard-AI/src/anomaly_agent/phase_aware_handler.py:406:4-409:27) method
- Added `Dict[str, Dict[str, List[float]]]` type to [by_satellite](cci:1://file:///d:/Contribution/AstraGuard-AI/src/astraguard/hil/metrics/latency.py:162:4-196:20) variable
- Added `Dict[str, Dict[str, Any]]` type to [stats](cci:1://file:///d:/Contribution/AstraGuard-AI/src/astraguard/hil/metrics/latency.py:128:4-161:20) variable
- Added [(n: int) -> float](cci:1://file:///d:/Contribution/AstraGuard-AI/src/astraguard/hil/metrics/latency.py:251:4-254:37) type to nested [nth_smallest](cci:1://file:///d:/Contribution/AstraGuard-AI/src/astraguard/hil/metrics/latency.py:272:8-273:85) function

## Verification
- Passes `mypy --config-file mypy.ini`  
- Passes `mypy --strict`  
- No behavioral changes

## Files Modified
- [src/astraguard/hil/metrics/latency.py](cci:7://file:///d:/Contribution/AstraGuard-AI/src/astraguard/hil/metrics/latency.py:0:0-0:0)