### PR TITLE
test: Add behavior-driven unit tests for app.py (Fixes #69))

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,11 +266,14 @@ def setup_test_environment():
 @pytest.fixture(autouse=True)
 def reset_singletons():
     """Reset singleton instances between tests."""
-    from core.component_health import SystemHealthMonitor
-    # Save original instances
-    yield
-    # Reset after each test
-    SystemHealthMonitor._instance = None
+    try:
+        from core.component_health import SystemHealthMonitor
+        yield
+        # Reset after each test
+        SystemHealthMonitor._instance = None
+    except (ImportError, ModuleNotFoundError):
+        # Skip if dependencies not available
+        yield
 
 
 # ============================================================================


### PR DESCRIPTION
- Replace source-inspection tests with 35 behavior-driven tests
- Tests validate runtime behavior via mocks and assertions on:
  - SystemExit codes for error conditions
  - Mock calls to uvicorn.run with correct parameters
  - Logger calls for startup/error/warning messages
  - Signal handler registration (SIGINT/SIGTERM)
- Cover port validation, log level validation, error handling
- Fix conftest.py reset_singletons to handle missing dependencies
- No production code changes