### PR TITLE
fix(ci): correct Docker Compose volume mounts for integration tests (#799)

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -24,13 +24,13 @@ services:
       redis:
         condition: service_healthy
     volumes:
-      - ./backend:/app/backend
-      - ./anomaly:/app/anomaly
-      - ./core:/app/core
-      - ./state_machine:/app/state_machine
-      - ./memory_engine:/app/memory_engine
-      - ./config:/app/config
-      - ./logs:/app/logs
+      - ../../src/backend:/app/backend
+      - ../../src/anomaly:/app/anomaly
+      - ../../src/core:/app/core
+      - ../../src/state_machine:/app/state_machine
+      - ../../src/memory_engine:/app/memory_engine
+      - ../../src/config:/app/config
+      - ../../logs:/app/logs
       - app_cache:/app/.cache
     networks:
       - astra-network


### PR DESCRIPTION


This commit fixes the Full Stack Integration Test failures in the CI/CD pipeline.

Root Cause:
The infra/docker/docker-compose.yml file used relative paths (e.g., ./backend) for volume mounts. These paths were incorrect when executed from the CI environment or even locally if not running from the exact directory expected, causing the Docker containers to start with empty source code directories.

Fix:
Updated all volume mounts to use paths relative to the src directory (e.g., ../../src/backend), ensuring that the application code is correctly mounted into the containers regardless of the execution context.

Verification:
- Validated locally with docker compose config.
- Verified stack startup with docker compose up.
- Passed 	ests/swarm/integration/test_full_integration.py::test_complete_swarm_pipeline.

Closes #799