### PR TITLE
fix(ci): update docker-compose volume mounts for integration tests (#799)

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -24,13 +24,13 @@ services:
       redis:
         condition: service_healthy
     volumes:
-      - ./backend:/app/backend
-      - ./anomaly:/app/anomaly
-      - ./core:/app/core
-      - ./state_machine:/app/state_machine
-      - ./memory_engine:/app/memory_engine
-      - ./config:/app/config
-      - ./logs:/app/logs
+      - ../../src/backend:/app/backend
+      - ../../src/anomaly:/app/anomaly
+      - ../../src/core:/app/core
+      - ../../src/state_machine:/app/state_machine
+      - ../../src/memory_engine:/app/memory_engine
+      - ../../src/config:/app/config
+      - ../../logs:/app/logs
       - app_cache:/app/.cache
     networks:
       - astra-network


### PR DESCRIPTION
### 🐛 Bug Fix: Correct Docker Compose Volume Mounts for Integration Tests (#799)

This PR fixes the Full Stack Integration Test failures in the CI/CD pipeline by correcting the Docker volume mounts.

#### 🔍 Root Cause
The [infra/docker/docker-compose.yml](AstraGuard-AI-Apertre-3.0/infra/docker/docker-compose.yml:0:0-0:0) file was using relative paths (e.g., `./backend`) for volume mounts. These paths were incorrect relative to where the compose file resides and how it is executed in CI, causing the Docker containers to start with empty source code directories.

#### 🛠️ Fix Implemented
Updated all volume mounts to use correct relative paths pointing to the `src` directory (e.g., `../../src/backend`). This ensures that the application code is correctly mounted into the containers regardless of whether `docker compose` is run from the root or the `infra/docker` directory.

#### ✅ Verification
- **Local Test**: Ran `python -m pytest tests/swarm/integration/test_full_integration.py::test_complete_swarm_pipeline`
- **Result**: PASSED (1 passed, 0 failed)
- **Manual Check**: Verified `docker compose config` resolves paths correctly.

#### 🔗 Related Issue
Closes #799