### PR TITLE
fix(ci): increase swarm sim timeouts and optimize health checks (#798)

### DIFF
--- a/infra/docker/docker-compose.swarm.yml
+++ b/infra/docker/docker-compose.swarm.yml
@@ -70,10 +70,10 @@ services:
     
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health/live"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 20s
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 45s
     
     restart: unless-stopped
 
@@ -123,10 +123,10 @@ services:
     
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health/live"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 20s
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 45s
     
     restart: unless-stopped
 
@@ -175,10 +175,10 @@ services:
     
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health/live"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 20s
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 45s
     
     restart: unless-stopped
 
@@ -227,10 +227,10 @@ services:
     
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health/live"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 20s
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 45s
     
     restart: unless-stopped
 
@@ -279,10 +279,10 @@ services:
     
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health/live"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 20s
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 45s
     
     restart: unless-stopped
 

--- a/tests/swarm/test_swarm_sim.py
+++ b/tests/swarm/test_swarm_sim.py
@@ -98,14 +98,14 @@ class SwarmSimulatorOrchestrator:
                 ["docker-compose", "-f", self.compose_file, "up", "-d"],
                 capture_output=True,
                 text=True,
-                timeout=120
+                timeout=300
             )
             if result.returncode != 0:
                 logger.error(f"docker-compose failed: {result.stderr}")
                 return False
             
             # Wait for all agents healthy
-            await self._wait_for_agents_healthy(timeout=120)
+            await self._wait_for_agents_healthy(timeout=300)
             logger.info("✓ All agents healthy")
             return True
         except Exception as e:
@@ -127,7 +127,7 @@ class SwarmSimulatorOrchestrator:
             logger.error(f"Failed to stop constellation: {e}")
             return False
     
-    async def _wait_for_agents_healthy(self, timeout: int = 120):
+    async def _wait_for_agents_healthy(self, timeout: int = 300):
         """Wait for all agents to pass health checks."""
         start = datetime.now()
         logger.info(f"Waiting up to {timeout}s for agents to become healthy...")


### PR DESCRIPTION
This commit addresses the persistent timeouts in the Swarm Simulator workflow.

Changes:
- Increased test orchestrator timeouts from 120s to 300s to allow for slower CI environments.
- Optimized Docker health checks:
  - Increased start_period to 45s (was 20s).
  - Increased interval to 15s and retries to 5 to reduce CPU load and flakiness.

Closes #798
### 🐛 Bug Fix: Swarm Simulator Test Timeouts (#798)

This PR resolves the persistent timeouts in the Swarm Simulator Tests workflow by optimizing configuration for the CI environment.

#### 🔍 Root Cause
The previous 120s hard timeout for the 5-agent constellation to become healthy was too aggressive for shared CI runners, leading to premature test failures even when the system was just starting up slowly.

#### 🛠️ Fix Implemented
1.  **Increased Orchestrator Timeouts**: Updated `tests/swarm/test_swarm_sim.py` to wait up to **300 seconds** (5 mins) for the constellation to stabilize.
2.  **Optimized Health Checks**: Updated `infra/docker/docker-compose.swarm.yml` to:
    - Increase `start_period` to **45s** (was 20s).
    - Increase `interval` to **15s** (was 10s) and `retries` to **5**.
    - Increase `timeout` to **10s**.

#### ✅ Verification
- **Local Validation**: Code logic verified for correctness.
- **CI Impact**: These changes directly address the timeout symptoms (failure at 6-8 mins) by extending the allowed startup window.

#### 🔗 Related Issue
Closes #798