### PR TITLE
feat(ci): add debug-tests workflow for diagnosing failures

### DIFF
--- a/.github/workflows/debug-tests.yml
+++ b/.github/workflows/debug-tests.yml
@@ -1,0 +1,130 @@
+name: Debug Test Failures
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_target:
+        description: 'Test file or directory to run (e.g., tests/test_memory_store.py)'
+        required: true
+        default: 'tests/'
+        type: string
+      verbosity:
+        description: 'Pytest verbosity level'
+        required: true
+        default: '-vv'
+        type: choice
+        options:
+          - '-v'
+          - '-vv'
+          - '-vvv'
+      trace_on_fail:
+        description: 'Enable trace on failure (--trace)'
+        required: false
+        default: false
+        type: boolean
+      fail_fast:
+        description: 'Stop on first failure (-x)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  debug-test:
+    name: Debug Test Run
+    runs-on: ubuntu-latest
+    
+    services:
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+    - name: Free up disk space
+      run: |
+        echo "Freeing up disk space before checkout..."
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /opt/hostedtoolcache/Python* || true
+        df -h
+    
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -r src/config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -r src/config/requirements-test.txt
+    
+    - name: Wait for Redis
+      run: |
+        python -c "
+        import redis, time, sys, socket
+        for i in range(30):
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(2)
+                result = sock.connect_ex(('localhost', 6379))
+                sock.close()
+                if result == 0:
+                    r = redis.Redis(host='localhost', port=6379, socket_connect_timeout=5, decode_responses=True)
+                    pong = r.ping()
+                    if pong:
+                        print('Redis is ready!')
+                        sys.exit(0)
+            except Exception as e:
+                pass
+            print(f'Waiting for Redis... ({i+1}/30)', flush=True)
+            time.sleep(1)
+        print('ERROR: Redis connection timeout after 30 attempts')
+        sys.exit(1)
+        "
+
+    - name: Construct Pytest Arguments
+      id: args
+      run: |
+        ARGS="${{ inputs.verbosity }}"
+        if [ "${{ inputs.trace_on_fail }}" = "true" ]; then
+          ARGS="$ARGS --trace"
+        fi
+        if [ "${{ inputs.fail_fast }}" = "true" ]; then
+          ARGS="$ARGS -x"
+        fi
+        echo "pytest_args=$ARGS" >> $GITHUB_OUTPUT
+
+    - name: Run Pytest (Debug Mode)
+      env:
+        REDIS_URL: redis://localhost:6379
+      run: |
+        echo "Running tests on target: ${{ inputs.test_target }}"
+        echo "Arguments: ${{ steps.args.outputs.pytest_args }}"
+        
+        # Capture output to file for artifact upload, but also stream to console
+        pytest ${{ inputs.test_target }} \
+          ${{ steps.args.outputs.pytest_args }} \
+          --capture=no \
+          --tb=long \
+          2>&1 | tee test_output.log
+        
+        # Exit with piped command status
+        exit ${PIPESTATUS[0]}
+
+    - name: Upload Test Logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-test-logs
+        path: test_output.log
+        retention-days: 7


### PR DESCRIPTION
Add Debug Workflow for Test Failures (#795)
Implements a dedicated GitHub Actions workflow (
debug-tests.yml
) to diagnose test failures efficiently without running the full test suite.

Problem
The existing CI workflow runs all tests with coverage analysis, making it slow and resource-intensive to debug specific failures. Detailed logs are often buried, and artifacts are not always captured.

Solution
Created a manual workflow (workflow_dispatch) that allows:

Targeted Execution: Run specific test files or directories via test_target input.
Verbose Logging: Configurable verbosity (-v, -vv, -vvv).
Debugging Flags: Optional --trace (pdb) and -x (fail-fast) flags.
Artifact Collection: Captures test_output.log for offline analysis.
Faster Feedback: Skips coverage checks and unrelated steps.
Verification
Validated workflow syntax and structure against 
tests.yml
.
Replicated exact environment setup (Python 3.11, Redis service) to ensure consistency with main CI.
Checklist
 Create 
.github/workflows/debug-tests.yml
 Configure inputs and defaults
 Replicate CI environment (services, dependencies)
 implement artifact upload