### PR TITLE
feat(infra): Create service mesh (Istio) configuration (#543)

### DIFF
--- a/infra/k8s/istio/gateway.yaml
+++ b/infra/k8s/istio/gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: astraguard-gateway
+  namespace: astraguard
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "astraguard.ai"

--- a/infra/k8s/istio/virtual-service.yaml
+++ b/infra/k8s/istio/virtual-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: astraguard-vs
+  namespace: astraguard
+spec:
+  hosts:
+  - "astraguard.ai"
+  gateways:
+  - astraguard-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /api
+    route:
+    - destination:
+        host: astraguard-api
+        port:
+          number: 8000
+  - route:
+    - destination:
+        host: astraguard-ui
+        port:
+          number: 3000

--- a/infra/k8s/logging/sidecar-config.yaml
+++ b/infra/k8s/logging/sidecar-config.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: astraguard
+data:
+  fluent.conf: |
+    <source>
+      @type tail
+      path /var/log/astraguard/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      tag astraguard.*
+      <parse>
+        @type json
+      </parse>
+    </source>
+    <match **>
+      @type stdout
+    </match>
+---
+# Example Pod Patch for Sidecar
+apiVersion: v1
+kind: Pod
+metadata:
+  name: astraguard-api
+spec:
+  containers:
+  - name: astraguard-api
+    image: astraguard:latest
+    volumeMounts:
+    - name: logs
+      mountPath: /var/log/astraguard
+  - name: fluentd-sidecar
+    image: fluent/fluentd:v1.16
+    volumeMounts:
+    - name: config-volume
+      mountPath: /fluentd/etc/
+    - name: logs
+      mountPath: /var/log/astraguard
+  volumes:
+  - name: config-volume
+    configMap:
+      name: fluentd-config
+  - name: logs
+    emptyDir: {}


### PR DESCRIPTION
Adds Istio Gateway and VirtualService configuration.\n\nCloses #543


 feat(infra): Create service mesh (Istio) configuration (#543)
Closes: #543 Description: Adds Istio Gateway and VirtualService configuration.

File: 
infra/k8s/istio/gateway.yaml

yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: astraguard-gateway
  namespace: astraguard
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - "astraguard.ai"

