### PR TITLE
feat(infra): Create sidecar containers for logging (#542)

### DIFF
--- a/infra/k8s/logging/sidecar-config.yaml
+++ b/infra/k8s/logging/sidecar-config.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: astraguard
+data:
+  fluent.conf: |
+    <source>
+      @type tail
+      path /var/log/astraguard/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      tag astraguard.*
+      <parse>
+        @type json
+      </parse>
+    </source>
+    <match **>
+      @type stdout
+    </match>
+---
+# Example Pod Patch for Sidecar
+apiVersion: v1
+kind: Pod
+metadata:
+  name: astraguard-api
+spec:
+  containers:
+  - name: astraguard-api
+    image: astraguard:latest
+    volumeMounts:
+    - name: logs
+      mountPath: /var/log/astraguard
+  - name: fluentd-sidecar
+    image: fluent/fluentd:v1.16
+    volumeMounts:
+    - name: config-volume
+      mountPath: /fluentd/etc/
+    - name: logs
+      mountPath: /var/log/astraguard
+  volumes:
+  - name: config-volume
+    configMap:
+      name: fluentd-config
+  - name: logs
+    emptyDir: {}


### PR DESCRIPTION
 feat(infra): Create sidecar containers for logging (#542)
Closes: #542 Description: Adds ConfigMap and Pod patch for Fluentd sidecar logging.

File: 
infra/k8s/logging/sidecar-config.yaml

yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: fluentd-config
  namespace: astraguard
data:
  fluent.conf: |
    <source>
      @type tail
      path /var/log/astraguard/*.log
      pos_file /var/log/fluentd-containers.log.pos
      tag astraguard.*
      <parse>
        @type json
      </parse>
    </source>
    <match **>
      @type stdout
    </match>