### PR TITLE
feat(infra): Create distributed tracing with Jaeger (#544)

### DIFF
--- a/infra/k8s/tracing/jaeger-deployment.yaml
+++ b/infra/k8s/tracing/jaeger-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+      - name: jaeger
+        image: jaegertracing/all-in-one:1.50
+        ports:
+        - containerPort: 16686
+        - containerPort: 14268
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: observability
+spec:
+  selector:
+    app: jaeger
+  ports:
+    - name: ui
+      port: 16686
+      targetPort: 16686
+    - name: collector
+      port: 14268
+      targetPort: 14268


### PR DESCRIPTION
 feat(infra): Create distributed tracing with Jaeger (#544)
Closes: #544 Description: Adds Jaeger All-in-One deployment for distributed tracing.

File: 
infra/k8s/tracing/jaeger-deployment.yaml

yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: jaeger
  namespace: observability
spec:
  replicas: 1
  selector:
    matchLabels:
      app: jaeger
  template:
    metadata:
      labels:
        app: jaeger
    spec:
      containers:
      - name: jaeger
        image: jaegertracing/all-in-one:1.50
        ports:
        - containerPort: 16686
        - containerPort: 14268