### PR TITLE
feat(infra): Create namespace isolation strategy (#546)

### DIFF
--- a/infra/k8s/namespaces/isolation-policy.yaml
+++ b/infra/k8s/namespaces/isolation-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-from-other-namespaces
+  namespace: astraguard
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+      namespaceSelector:
+        matchLabels:
+          name: astraguard
+    - namespaceSelector:
+        matchLabels:
+          name: observability # Allow monitoring tools


### PR DESCRIPTION
Adds NetworkPolicy to isolate namespaces, allowing only specific ingress.\n\nCloses #546


feat(infra): Create namespace isolation strategy (#546)
Closes: #546 Description: Adds NetworkPolicy to isolate namespaces.

File: 
infra/k8s/namespaces/isolation-policy.yaml

yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: deny-from-other-namespaces
  namespace: astraguard
spec:
  podSelector: {}
  policyTypes:
  - Ingress
  ingress:
  - from:
    - podSelector: {}
      namespaceSelector:
        matchLabels:
          name: astraguard
    - namespaceSelector:
        matchLabels:
          name: observability # Allow monitoring tools

