### PR TITLE
feat(ops): Create disaster recovery with cluster replication (#547)

### DIFF
--- a/infra/k8s/dr/velero-config.yaml
+++ b/infra/k8s/dr/velero-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: cluster-backup
+  namespace: velero
+spec:
+  schedule: "0 1 * * *" # Daily at 1 AM
+  template:
+    includedNamespaces:
+    - astraguard
+    ttl: 720h # 30 days


### PR DESCRIPTION
Adds Velero Schedule for cluster backups.\n\nCloses #547


feat(ops): Create disaster recovery with cluster replication (#547)
Closes: #547 Description: Adds Velero Schedule for cluster backups.

File: 
infra/k8s/dr/velero-config.yaml

yaml
apiVersion: velero.io/v1
kind: Schedule
metadata:
  name: cluster-backup
  namespace: velero
spec:
  schedule: "0 1 * * *" # Daily at 1 AM
  template:
    includedNamespaces:
    - astraguard
    ttl: 720h # 30 days
