### PR TITLE
feat(ops): Create multi-cluster deployment strategy (#548)

### DIFF
--- a/infra/k8s/multi-cluster/federation.yaml
+++ b/infra/k8s/multi-cluster/federation.yaml
@@ -1,0 +1,16 @@
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedDeployment
+metadata:
+  name: astraguard-api
+  namespace: astraguard
+spec:
+  template:
+    metadata:
+      labels:
+        app: astraguard-api
+    spec:
+      replicas: 3
+  placement:
+    clusters:
+    - name: cluster-us-east
+    - name: cluster-eu-west


### PR DESCRIPTION
 feat(ops): Create multi-cluster deployment strategy (#548)
Closes: #548 Description: Adds FederatedDeployment for multi-cluster strategy.

File: 
infra/k8s/multi-cluster/federation.yaml



apiVersion: types.kubefed.io/v1beta1
kind: FederatedDeployment
metadata:
  name: astraguard-api
  namespace: astraguard
spec:
  template:
    metadata:
      labels:
        app: astraguard-api
    spec:
      replicas: 3
  placement:
    clusters:
    - name: cluster-us-east
    - name: cluster-eu-west


