### PR TITLE
Feature/549 gitops argocd

### DIFF
--- a/infra/k8s/argocd/application.yaml
+++ b/infra/k8s/argocd/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: astraguard
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/sr-857/AstraGuard-AI-Apertre-3.0.git
+    targetRevision: HEAD
+    path: infra/helm/astraguard
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: astraguard
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/infra/k8s/multi-cluster/federation.yaml
+++ b/infra/k8s/multi-cluster/federation.yaml
@@ -1,0 +1,16 @@
+apiVersion: types.kubefed.io/v1beta1
+kind: FederatedDeployment
+metadata:
+  name: astraguard-api
+  namespace: astraguard
+spec:
+  template:
+    metadata:
+      labels:
+        app: astraguard-api
+    spec:
+      replicas: 3
+  placement:
+    clusters:
+    - name: cluster-us-east
+    - name: cluster-eu-west


### PR DESCRIPTION
 feat(ops): Implement GitOps with ArgoCD (#549)
Closes: #549 Description: Adds ArgoCD Application resource for GitOps.

File: 
infra/k8s/argocd/application.yaml

apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: astraguard
  namespace: argocd
spec:
  project: default
  source:
    repoURL: https://github.com/sr-857/AstraGuard-AI-Apertre-3.0.git
    targetRevision: HEAD
    path: infra/helm/astraguard
  destination:
    server: https://kubernetes.default.svc
    namespace: astraguard
  syncPolicy:
    automated:
      prune: true
      selfHeal: true
